### PR TITLE
Add of ADT to the project

### DIFF
--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -8,34 +8,62 @@ type Environment = HashMap<Name, Expression>;
 type TypeEnvironment = HashMap<Name, Vec<ValueConstructor>>; // Store ADT Definitions
 
 
-pub fn eval(exp: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+pub fn eval(exp: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     match exp {
-        Expression::Add(lhs, rhs) => add(*lhs, *rhs, env),
-        Expression::Sub(lhs, rhs) => sub(*lhs, *rhs, env),
-        Expression::Mul(lhs, rhs) => mul(*lhs, *rhs, env),
-        Expression::Div(lhs, rhs) => div(*lhs, *rhs, env),
-        Expression::Rmd(lhs, rhs) => rmd(*lhs, *rhs, env),
-        Expression::And(lhs, rhs) => and(*lhs, *rhs, env),
-        Expression::Or(lhs, rhs) => or(*lhs, *rhs, env),
-        Expression::Not(lhs) => not(*lhs, env),
-        Expression::EQ(lhs, rhs) => eq(*lhs, *rhs, env),
-        Expression::GT(lhs, rhs) => gt(*lhs, *rhs, env),
-        Expression::LT(lhs, rhs) => lt(*lhs, *rhs, env),
-        Expression::GTE(lhs, rhs) => gte(*lhs, *rhs, env),
-        Expression::LTE(lhs, rhs) => lte(*lhs, *rhs, env),
+        Expression::Add(lhs, rhs) => add(*lhs, *rhs, env,type_env),
+        Expression::Sub(lhs, rhs) => sub(*lhs, *rhs, env,type_env),
+        Expression::Mul(lhs, rhs) => mul(*lhs, *rhs, env,type_env),
+        Expression::Div(lhs, rhs) => div(*lhs, *rhs, env,type_env),
+        Expression::Rmd(lhs, rhs) => rmd(*lhs, *rhs, env,type_env),
+        Expression::And(lhs, rhs) => and(*lhs, *rhs, env,type_env),
+        Expression::Or(lhs, rhs) => or(*lhs, *rhs, env,type_env),
+        Expression::Not(lhs) => not(*lhs, env, type_env),
+        Expression::EQ(lhs, rhs) => eq(*lhs, *rhs, env, type_env),
+        Expression::GT(lhs, rhs) => gt(*lhs, *rhs, env, type_env),
+        Expression::LT(lhs, rhs) => lt(*lhs, *rhs, env, type_env),
+        Expression::GTE(lhs, rhs) => gte(*lhs, *rhs, env, type_env),
+        Expression::LTE(lhs, rhs) => lte(*lhs, *rhs, env, type_env),
         Expression::Var(name) => lookup(name, env),
-        Expression::Constructor(name, args) => {
-            let evaluated_args: Result<Vec<Box<Expression>>, ErrorMessage> = 
-                args.into_iter()
-                    .map(|arg| eval(*arg, env).map(Box::new))
-                    .collect();
-            
-            evaluated_args.map(|evaluated| Expression::Constructor(name, evaluated))
-        }
+        Expression::Constructor(name, args) => constructor_eval(name, args, env, type_env),
         _ if is_constant(exp.clone()) => Ok(exp),
         _ => Err(String::from("Not implemented yet.")),
     }
 }
+
+
+fn constructor_eval(
+    name: Name, 
+    args: Vec<Box<Expression>>, 
+    env: &Environment, 
+    type_env: &TypeEnvironment
+) -> Result<Expression, ErrorMessage> {
+    // Verifica se o construtor está registrado em algum ADT dentro de `type_env`
+    let value_constructor = type_env
+        .values()  // Pega todas as listas de `ValueConstructor`
+        .flatten() // Achata para iterar sobre cada `ValueConstructor`
+        .find(|vc| vc.name == name);
+
+    if let Some(vc) = value_constructor {
+        // Verifica se o número de argumentos bate com o esperado
+        if vc.types.len() != args.len() {
+            return Err(format!(
+                "Erro: {} espera {} argumentos, mas recebeu {}",
+                name, vc.types.len(), args.len()
+            ));
+        }
+
+        // Avalia os argumentos recursivamente
+        let evaluated_args: Result<Vec<Box<Expression>>, ErrorMessage> = 
+            args.into_iter()
+                .map(|arg| eval(*arg, env, type_env).map(Box::new))
+                .collect();
+
+        evaluated_args.map(|evaluated| Expression::Constructor(name, evaluated))
+    } else {
+        Err(format!("Erro: Construtor {} não encontrado", name))
+    }
+}
+
 
 fn is_constant(exp: Expression) -> bool {
     match exp {
@@ -54,20 +82,20 @@ fn lookup(name: String, env: &Environment) -> Result<Expression, ErrorMessage> {
         None => Err(format!("Variable {} not found", name)),
     }
 }
-
 /* Arithmetic Operations */
 fn eval_binary_arith_op<F>(
     lhs: Expression,
     rhs: Expression,
     env: &Environment,
+    type_env: &TypeEnvironment,
     op: F,
     error_msg: &str,
 ) -> Result<Expression, ErrorMessage>
 where 
     F: Fn(f64, f64) -> f64,
 {
-    let v1 = eval(lhs, env)?;
-    let v2 = eval(rhs, env)?;
+    let v1 = eval(lhs, env, type_env)?;
+    let v2 = eval(rhs, env, type_env)?;
     match (v1, v2) {
         (Expression::CInt(v1), Expression::CInt(v2)) => {
             Ok(Expression::CInt(op(v1 as f64, v2 as f64) as i32))
@@ -79,68 +107,75 @@ where
     }
 }
 
-fn add(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn add(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_arith_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| a + b,
         "addition '(+)' is only defined for numbers (integers and real).",
     )
 }
 
-fn sub(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn sub(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_arith_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| a - b,
         "subtraction '(-)' is only defined for numbers (integers and real).",
     )
 }
 
-fn mul(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn mul(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_arith_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| a * b,
         "multiplication '(*)' is only defined for numbers (integers and real).",
     )
 }
 
-fn div(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn div(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_arith_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| a / b,
         "division '(/)' is only defined for numbers (integers and real).",
     )
 }
 
-fn rmd(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn rmd(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_arith_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| a % b,
         "Remainder operation '(%)' is only defined for numbers (integers and real).",
     )
 }
+
 /* Boolean Expressions */
 fn eval_binary_boolean_op<F>(
     lhs: Expression,
     rhs: Expression,
     env: &Environment,
+    type_env: &TypeEnvironment,
     op: F,
     error_msg: &str,
 ) -> Result<Expression, ErrorMessage>
 where
     F: Fn(bool, bool) -> Expression,
 {
-    let v1 = eval(lhs, env)?;
-    let v2 = eval(rhs, env)?;
+    let v1 = eval(lhs, env, type_env)?;
+    let v2 = eval(rhs, env, type_env)?;
     match (v1, v2) {
         (Expression::CTrue, Expression::CTrue) => Ok(op(true, true)),
         (Expression::CTrue, Expression::CFalse) => Ok(op(true, false)),
@@ -150,11 +185,12 @@ where
     }
 }
 
-fn and(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn and(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_boolean_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| {
             if a && b {
                 Expression::CTrue
@@ -166,11 +202,12 @@ fn and(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression
     )
 }
 
-fn or(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn or(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_boolean_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| {
             if a || b {
                 Expression::CTrue
@@ -182,8 +219,9 @@ fn or(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression,
     )
 }
 
-fn not(lhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
-    let v = eval(lhs, env)?;
+
+fn not(lhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
+    let v = eval(lhs, env, type_env)?;
     match v {
         Expression::CTrue => Ok(Expression::CFalse),
         Expression::CFalse => Ok(Expression::CTrue),
@@ -191,19 +229,21 @@ fn not(lhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
     }
 }
 
+
 /* Relational Operations */
 fn eval_binary_rel_op<F>(
     lhs: Expression,
     rhs: Expression,
     env: &Environment,
+    type_env: &TypeEnvironment,
     op: F,
     error_msg: &str,
 ) -> Result<Expression, ErrorMessage>
 where
     F: Fn(f64, f64) -> Expression,
 {
-    let v1 = eval(lhs, env)?;
-    let v2 = eval(rhs, env)?;
+    let v1 = eval(lhs, env, type_env)?;
+    let v2 = eval(rhs, env, type_env)?;
     match (v1, v2) {
         (Expression::CInt(v1), Expression::CInt(v2)) => Ok(op(v1 as f64, v2 as f64)),
         (Expression::CInt(v1), Expression::CReal(v2)) => Ok(op(v1 as f64, v2)),
@@ -213,11 +253,12 @@ where
     }
 }
 
-fn eq(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn eq(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_rel_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| {
             if a == b {
                 Expression::CTrue
@@ -229,11 +270,13 @@ fn eq(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression,
     )
 }
 
-fn gt(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+
+fn gt(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_rel_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| {
             if a > b {
                 Expression::CTrue
@@ -245,11 +288,12 @@ fn gt(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression,
     )
 }
 
-fn lt(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn lt(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_rel_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| {
             if a < b {
                 Expression::CTrue
@@ -261,11 +305,12 @@ fn lt(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression,
     )
 }
 
-fn gte(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn gte(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_rel_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| {
             if a >= b {
                 Expression::CTrue
@@ -277,11 +322,12 @@ fn gte(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression
     )
 }
 
-fn lte(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
+fn lte(lhs: Expression, rhs: Expression, env: &Environment, type_env: &TypeEnvironment) -> Result<Expression, ErrorMessage> {
     eval_binary_rel_op(
         lhs,
         rhs,
         env,
+        type_env,
         |a, b| {
             if a <= b {
                 Expression::CTrue
@@ -293,224 +339,264 @@ fn lte(lhs: Expression, rhs: Expression, env: &Environment) -> Result<Expression
     )
 }
 
-pub fn execute(stmt: Statement, env: Environment, type_env: &mut TypeEnvironment) -> Result<Environment, ErrorMessage> {
+pub fn execute(
+    stmt: Statement,
+    env: &mut Environment,
+    type_env: &mut TypeEnvironment,
+) -> Result<Environment, ErrorMessage> {  // Return the updated environment
     match stmt {
         Statement::Assignment(name, exp) => {
-            let value = eval(*exp, &env)?;
-            let mut new_env = env;
-            new_env.insert(name.clone(), value);
-            Ok(new_env.clone())
+            let value = eval(*exp, env, type_env)?;
+            env.insert(name, value);
+            Ok(env.clone())  // Return the updated environment
         }
         Statement::IfThenElse(cond, stmt_then, stmt_else) => {
-            let value = eval(*cond, &env)?;
+            let value = eval(*cond, env, type_env)?;
             match value {
                 Expression::CTrue => execute(*stmt_then, env, type_env),
-                Expression::CFalse => match stmt_else {
-                    Some(else_statement) => execute(*else_statement, env, type_env),
-                    None => Ok(env),
-                },
-                _ => Err(String::from("expecting a boolean value.")),
+                Expression::CFalse => {
+                    if let Some(else_stmt) = stmt_else {
+                        execute(*else_stmt, env, type_env)
+                    } else {
+                        Ok(env.clone())  // Return the updated environment after execution
+                    }
+                }
+                _ => Err(String::from("Expecting a boolean value.")),
             }
         }
         Statement::While(cond, stmt) => {
-            let mut value = eval(*cond.clone(), &env)?;
-            let mut new_env = env;
-            while value == Expression::CTrue {
-                new_env = execute(*stmt.clone(), new_env.clone(), type_env)?;
-                value = eval(*cond.clone(), &new_env.clone())?;
+            while eval(*cond.clone(), env, type_env)? == Expression::CTrue {
+                execute(*stmt.clone(), env, type_env)?;
             }
-            Ok(new_env)
+            Ok(env.clone())  // Return the updated environment after the while loop
         }
-        Statement::Sequence(s1, s2) => execute(*s1, env, type_env).and_then(|new_env| execute(*s2, new_env, type_env)),
+        Statement::Sequence(s1, s2) => {
+            execute(*s1, env, type_env)?;
+            execute(*s2, env, type_env)
+        }
         Statement::ADTDeclaration(name, constructors) => {
             type_env.insert(name, constructors);
-            Ok(env)
+            Ok(env.clone())  // Return the updated environment (no changes made here, but you can return the same env)
         }
-        _ => Err(String::from("not implemented yet")),
+        _ => Err(String::from("Statement not implemented yet")),
     }
 }
+
 
 
 #[cfg(test)]
 mod tests {
 
+    use std::vec;
+
     use super::*;
     use crate::ir::ast::Expression::*;
     use crate::ir::ast::Statement::*;
+    use crate::ir::ast::Type;
     use approx::relative_eq;
 
     #[test]
     fn eval_constant() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c20 = CInt(20);
-
-        assert_eq!(eval(c10, &env), Ok(CInt(10)));
-        assert_eq!(eval(c20, &env), Ok(CInt(20)));
+    
+        assert_eq!(eval(c10, &env, &type_env), Ok(CInt(10)));
+        assert_eq!(eval(c20, &env, &type_env), Ok(CInt(20)));
     }
-
+    
     #[test]
     fn eval_add_expression1() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c20 = CInt(20);
         let add1 = Add(Box::new(c10), Box::new(c20));
-        assert_eq!(eval(add1, &env), Ok(CInt(30)));
+    
+        assert_eq!(eval(add1, &env, &type_env), Ok(CInt(30)));
     }
-
+    
     #[test]
     fn eval_add_expression2() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c20 = CInt(20);
         let c30 = CInt(30);
         let add1 = Add(Box::new(c10), Box::new(c20));
         let add2 = Add(Box::new(add1), Box::new(c30));
-        assert_eq!(eval(add2, &env), Ok(CInt(60)));
+    
+        assert_eq!(eval(add2, &env, &type_env), Ok(CInt(60)));
     }
-
+    
     #[test]
     fn eval_add_expression3() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c20 = CReal(20.5);
         let add1 = Add(Box::new(c10), Box::new(c20));
-        assert_eq!(eval(add1, &env), Ok(CReal(30.5)));
+    
+        assert_eq!(eval(add1, &env, &type_env), Ok(CReal(30.5)));
     }
-
+    
     #[test]
     fn eval_sub_expression1() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c20 = CInt(20);
         let sub1 = Sub(Box::new(c20), Box::new(c10));
-        assert_eq!(eval(sub1, &env), Ok(CInt(10)));
+    
+        assert_eq!(eval(sub1, &env, &type_env), Ok(CInt(10)));
     }
-
+    
     #[test]
     fn eval_sub_expression2() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c100 = CInt(100);
         let c200 = CInt(300);
         let sub1 = Sub(Box::new(c200), Box::new(c100));
-        assert_eq!(eval(sub1, &env), Ok(CInt(200)));
+    
+        assert_eq!(eval(sub1, &env, &type_env), Ok(CInt(200)));
     }
-
+    
     #[test]
     fn eval_sub_expression3() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c100 = CReal(100.5);
         let c300 = CInt(300);
         let sub1 = Sub(Box::new(c300), Box::new(c100));
-        assert_eq!(eval(sub1, &env), Ok(CReal(199.5)));
+    
+        assert_eq!(eval(sub1, &env, &type_env), Ok(CReal(199.5)));
     }
-
+    
     #[test]
     fn eval_mul_expression1() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c20 = CInt(20);
         let mul1 = Mul(Box::new(c10), Box::new(c20));
-        assert_eq!(eval(mul1, &env), Ok(CInt(200)));
+    
+        assert_eq!(eval(mul1, &env, &type_env), Ok(CInt(200)));
     }
-
+    
     #[test]
     fn eval_mul_expression2() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CReal(10.5);
         let c20 = CInt(20);
         let mul1 = Mul(Box::new(c10), Box::new(c20));
-        assert_eq!(eval(mul1, &env), Ok(CReal(210.0)));
+    
+        assert_eq!(eval(mul1, &env, &type_env), Ok(CReal(210.0)));
     }
-
+    
     #[test]
     fn eval_div_expression1() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c20 = CInt(20);
         let div1 = Div(Box::new(c20), Box::new(c10));
-        assert_eq!(eval(div1, &env), Ok(CInt(2)));
+    
+        assert_eq!(eval(div1, &env, &type_env), Ok(CInt(2)));
     }
-
+    
     #[test]
     fn eval_div_expression2() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c3 = CInt(3);
         let div1 = Div(Box::new(c10), Box::new(c3));
-        assert_eq!(eval(div1, &env), Ok(CInt(3)));
+    
+        assert_eq!(eval(div1, &env, &type_env), Ok(CInt(3)));
     }
-
+    
     #[test]
     fn eval_div_expression3() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c3 = CInt(3);
         let c21 = CInt(21);
         let div1 = Div(Box::new(c21), Box::new(c3));
-        assert_eq!(eval(div1, &env), Ok(CInt(7)));
+    
+        assert_eq!(eval(div1, &env, &type_env), Ok(CInt(7)));
     }
-
+    
     #[test]
     fn eval_div_expression4() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let c10 = CInt(10);
         let c3 = CReal(3.0);
         let div1 = Div(Box::new(c10), Box::new(c3));
-        let res = eval(div1, &env);
+        let res = eval(div1, &env, &type_env);
+    
         match res {
             Ok(CReal(v)) => assert!(relative_eq!(v, 3.3333333333333335, epsilon = f64::EPSILON)),
             Err(msg) => assert!(false, "{}", msg),
             _ => assert!(false, "Not expected."),
         }
     }
+    
 
     #[test]
     fn eval_variable() {
         let env = HashMap::from([(String::from("x"), CInt(10)), (String::from("y"), CInt(20))]);
+        let type_env = HashMap::new();
         let v1 = Var(String::from("x"));
         let v2 = Var(String::from("y"));
-        assert_eq!(eval(v1, &env), Ok(CInt(10)));
-        assert_eq!(eval(v2, &env), Ok(CInt(20)));
+        assert_eq!(eval(v1, &env, &type_env), Ok(CInt(10)));
+        assert_eq!(eval(v2, &env, &type_env), Ok(CInt(20)));
     }
 
     #[test]
     fn eval_expression_with_variables() {
         let env = HashMap::from([(String::from("a"), CInt(5)), (String::from("b"), CInt(3))]);
+        let type_env = HashMap::new();
         let expr = Mul(
             Box::new(Var(String::from("a"))),
             Box::new(Add(Box::new(Var(String::from("b"))), Box::new(CInt(2)))),
         );
-        assert_eq!(eval(expr, &env), Ok(CInt(25)));
+        assert_eq!(eval(expr, &env, &type_env), Ok(CInt(25)));
     }
 
     #[test]
     fn eval_nested_expressions() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let expr = Add(
             Box::new(Mul(Box::new(CInt(2)), Box::new(CInt(3)))),
             Box::new(Sub(Box::new(CInt(10)), Box::new(CInt(4)))),
         );
-        assert_eq!(eval(expr, &env), Ok(CInt(12)));
+        assert_eq!(eval(expr, &env, &type_env), Ok(CInt(12)));
     }
 
     #[test]
     fn eval_variable_not_found() {
         let env = HashMap::new();
+        let type_env = HashMap::new();
         let var_expr = Var(String::from("z"));
 
         assert_eq!(
-            eval(var_expr, &env),
+            eval(var_expr, &env, &type_env),
             Err(String::from("Variable z not found"))
         );
     }
 
     #[test]
     fn execute_assignment() {
-        let env = HashMap::new();
+        let mut env = HashMap::new();
         let mut type_env = HashMap::new(); // Include TypeEnvironment
         let assign_stmt = Statement::Assignment(String::from("x"), Box::new(Expression::CInt(42)));
     
-        match execute(assign_stmt, env, &mut type_env) {
+        match execute(assign_stmt, &mut env, &mut type_env) {
             Ok(new_env) => assert_eq!(new_env.get("x"), Some(&Expression::CInt(42))),
             Err(s) => panic!("{}", s), // Use `panic!` instead of `assert!(false, ...)`
         }
@@ -531,7 +617,7 @@ mod tests {
          * After executing this program, 'x' must be zero and
          * 'y' must be 55.
          */
-        let env = HashMap::new();
+        let mut env = HashMap::new();
         let mut type_env = HashMap::new(); // Include TypeEnvironment
 
         let a1 = Assignment(String::from("x"), Box::new(CInt(10)));
@@ -558,7 +644,7 @@ mod tests {
         let seq2 = Sequence(Box::new(a2), Box::new(while_statement));
         let program = Sequence(Box::new(a1), Box::new(seq2));
 
-        match execute(program, env, &mut type_env) {
+        match execute(program, &mut env, &mut type_env) {
             Ok(new_env) => {
                 assert_eq!(new_env.get("y"), Some(&CInt(55)));
                 assert_eq!(new_env.get("x"), Some(&CInt(0)));
@@ -580,7 +666,7 @@ mod tests {
          *
          * After executing, 'y' should be 1.
          */
-        let env = HashMap::new();
+        let mut env = HashMap::new();
         let mut type_env = HashMap::new(); // Include TypeEnvironment
 
         let condition = GT(Box::new(Var(String::from("x"))), Box::new(CInt(5)));
@@ -596,7 +682,7 @@ mod tests {
         let setup_stmt = Assignment(String::from("x"), Box::new(CInt(10)));
         let program = Sequence(Box::new(setup_stmt), Box::new(if_statement));
 
-        match execute(program, env, &mut type_env) {
+        match execute(program, &mut env, &mut type_env) {
             Ok(new_env) => assert_eq!(new_env.get("y"), Some(&CInt(1))),
             Err(s) => assert!(false, "{}", s),
         }
@@ -619,7 +705,7 @@ mod tests {
          * After executing, 'y' should be 2.
          */
 
-        let env = HashMap::new();
+        let mut env = HashMap::new();
         let mut type_env = HashMap::new(); // Include TypeEnvironment
 
         let second_condition = LT(Box::new(Var(String::from("x"))), Box::new(CInt(0)));
@@ -649,7 +735,7 @@ mod tests {
         let first_assignment = Assignment(String::from("x"), Box::new(CInt(1)));
         let program = Sequence(Box::new(first_assignment), Box::new(setup_stmt));
 
-        match execute(program, env, &mut type_env) {
+        match execute(program, &mut env, &mut type_env) {
             Ok(new_env) => assert_eq!(new_env.get("y"), Some(&CInt(2))),
             Err(s) => assert!(false, "{}", s),
         }
@@ -674,86 +760,94 @@ mod tests {
          *   After processing 'x' must be 43
          *   and 'z' must be 27
          */
-
-        let env = HashMap::new();
+    
+        let mut env = HashMap::new();
         let mut type_env = HashMap::new(); // Include TypeEnvironment
-        let a1 = Assignment(String::from("x"), Box::new(CInt(1)));
-        let a2 = Assignment(String::from("y"), Box::new(CInt(1800)));
-        let a3 = Assignment(String::from("z"), Box::new(CInt(0)));
-        let a4 = Assignment(
+    
+        // Initialize variables
+        let a1 = Statement::Assignment(String::from("x"), Box::new(Expression::CInt(1)));
+        let a2 = Statement::Assignment(String::from("y"), Box::new(Expression::CInt(1800)));
+        let a3 = Statement::Assignment(String::from("z"), Box::new(Expression::CInt(0)));
+        let a4 = Statement::Assignment(
             String::from("z"),
-            Box::new(Add(Box::new(Var(String::from("z"))), Box::new(CInt(1)))),
+            Box::new(Expression::Add(Box::new(Expression::Var(String::from("z"))), Box::new(Expression::CInt(1)))),
         );
-        let a5 = Assignment(
+        let a5 = Statement::Assignment(
             String::from("z"),
-            Box::new(Add(Box::new(Var(String::from("z"))), Box::new(CInt(1)))),
+            Box::new(Expression::Add(Box::new(Expression::Var(String::from("z"))), Box::new(Expression::CInt(1)))),
         );
-        let a6 = Assignment(
+        let a6 = Statement::Assignment(
             String::from("x"),
-            Box::new(Add(Box::new(Var(String::from("x"))), Box::new(CInt(1)))),
+            Box::new(Expression::Add(Box::new(Expression::Var(String::from("x"))), Box::new(Expression::CInt(1)))),
         );
-
-        let if_statement1 = IfThenElse(
-            Box::new(EQ(
-                Box::new(Rmd(Box::new(Var(String::from("x"))), Box::new(CInt(2)))),
-                Box::new(CInt(0)),
+    
+        // Conditional checks for if statements
+        let if_statement1 = Statement::IfThenElse(
+            Box::new(Expression::EQ(
+                Box::new(Expression::Rmd(Box::new(Expression::Var(String::from("x"))), Box::new(Expression::CInt(2)))),
+                Box::new(Expression::CInt(0)),
             )),
             Box::new(a4),
             None,
         );
-        let if_statement2 = IfThenElse(
-            Box::new(EQ(
-                Box::new(Rmd(
-                    Box::new(Div(
-                        Box::new(Var(String::from("y"))),
-                        Box::new(Var(String::from("x"))),
+        let if_statement2 = Statement::IfThenElse(
+            Box::new(Expression::EQ(
+                Box::new(Expression::Rmd(
+                    Box::new(Expression::Div(
+                        Box::new(Expression::Var(String::from("y"))),
+                        Box::new(Expression::Var(String::from("x"))),
                     )),
-                    Box::new(CInt(2)),
+                    Box::new(Expression::CInt(2)),
                 )),
-                Box::new(CInt(0)),
+                Box::new(Expression::CInt(0)),
             )),
             Box::new(a5),
             None,
         );
-
-        let seq = Sequence(Box::new(if_statement1), Box::new(if_statement2));
-        let if_statement = IfThenElse(
-            Box::new(EQ(
-                Box::new(Rmd(
-                    Box::new(Var(String::from("y"))),
-                    Box::new(Var(String::from("x"))),
+    
+        let seq = Statement::Sequence(Box::new(if_statement1), Box::new(if_statement2));
+        let if_statement = Statement::IfThenElse(
+            Box::new(Expression::EQ(
+                Box::new(Expression::Rmd(
+                    Box::new(Expression::Var(String::from("y"))),
+                    Box::new(Expression::Var(String::from("x"))),
                 )),
-                Box::new(CInt(0)),
+                Box::new(Expression::CInt(0)),
             )),
             Box::new(seq),
             None,
         );
-
-        let seq1 = Sequence(Box::new(if_statement), Box::new(a6));
-
-        let while_statement = While(
-            Box::new(LTE(
-                Box::new(Mul(
-                    Box::new(Var(String::from("x"))),
-                    Box::new(Var(String::from("x"))),
+    
+        let seq1 = Statement::Sequence(Box::new(if_statement), Box::new(a6));
+    
+        // While loop execution
+        let while_statement = Statement::While(
+            Box::new(Expression::LTE(
+                Box::new(Expression::Mul(
+                    Box::new(Expression::Var(String::from("x"))),
+                    Box::new(Expression::Var(String::from("x"))),
                 )),
-                Box::new(Var(String::from("y"))),
+                Box::new(Expression::Var(String::from("y"))),
             )),
             Box::new(seq1),
         );
-
-        let seq2 = Sequence(Box::new(Sequence(Box::new(a1), Box::new(a2))), Box::new(a3));
-
-        let program = Sequence(Box::new(seq2), Box::new(while_statement));
-
-        match execute(program, env, &mut type_env) {
+    
+        let seq2 = Statement::Sequence(
+            Box::new(Statement::Sequence(Box::new(a1), Box::new(a2))),
+            Box::new(a3),
+        );
+    
+        let program = Statement::Sequence(Box::new(seq2), Box::new(while_statement));
+    
+        match execute(program, &mut env, &mut type_env) {
             Ok(new_env) => {
-                assert_eq!(new_env.get("x"), Some(&CInt(43)));
-                assert_eq!(new_env.get("z"), Some(&CInt(27)));
+                assert_eq!(new_env.get("x"), Some(&Expression::CInt(43)));
+                assert_eq!(new_env.get("z"), Some(&Expression::CInt(27)));
             }
             Err(s) => assert!(false, "{}", s),
         }
     }
+    
 
     #[test]
     fn eval_while_with_if() {
@@ -768,21 +862,22 @@ mod tests {
          *       m = (x + y) / 2
          *       if m*m <= z:
          *          a = m
-         *          x = mid + 1
+         *          x = m + 1
          *       else:
-         *          y = mid - 1
+         *          y = m - 1
          *
          *   After executing this program, 'x' must be 5,
          *   'y' must be 7 and 'a' must be 4
          */
-
-        let env = HashMap::new();
-        let mut type_env = HashMap::new(); 
-
+    
+        let mut env = HashMap::new();
+        let mut type_env = HashMap::new(); // Only need one type_env
+    
         let a1 = Assignment(String::from("x"), Box::new(CInt(1)));
         let a2 = Assignment(String::from("y"), Box::new(CInt(16)));
         let a3 = Assignment(String::from("z"), Box::new(CInt(16)));
         let a4 = Assignment(String::from("a"), Box::new(CInt(0)));
+        
         let a5 = Assignment(
             String::from("m"),
             Box::new(Div(
@@ -793,19 +888,22 @@ mod tests {
                 Box::new(CInt(2)),
             )),
         );
+    
         let a6 = Assignment(String::from("a"), Box::new(Var(String::from("m"))));
+        
         let a7 = Assignment(
             String::from("x"),
             Box::new(Add(Box::new(Var(String::from("m"))), Box::new(CInt(1)))),
         );
+    
         let a8 = Assignment(
             String::from("y"),
             Box::new(Sub(Box::new(Var(String::from("m"))), Box::new(CInt(1)))),
         );
-
+    
         let seq = Sequence(Box::new(a6), Box::new(a7));
-
-        let if_statement: Statement = IfThenElse(
+    
+        let if_statement = IfThenElse(
             Box::new(LTE(
                 Box::new(Mul(
                     Box::new(Var(String::from("m"))),
@@ -816,7 +914,7 @@ mod tests {
             Box::new(seq),
             Some(Box::new(a8)),
         );
-
+    
         let while_statement = While(
             Box::new(And(
                 Box::new(LTE(
@@ -833,7 +931,7 @@ mod tests {
             )),
             Box::new(Sequence(Box::new(a5), Box::new(if_statement))),
         );
-
+    
         let seq1 = Sequence(
             Box::new(a1),
             Box::new(Sequence(
@@ -841,10 +939,10 @@ mod tests {
                 Box::new(Sequence(Box::new(a3), Box::new(a4))),
             )),
         );
-
+    
         let program = Sequence(Box::new(seq1), Box::new(while_statement));
-
-        match execute(program, env,&mut type_env) {
+    
+        match execute(program, &mut env, &mut type_env) {
             Ok(new_env) => {
                 assert_eq!(new_env.get("x"), Some(&CInt(5)));
                 assert_eq!(new_env.get("y"), Some(&CInt(7)));
@@ -853,6 +951,7 @@ mod tests {
             Err(s) => assert!(false, "{}", s),
         }
     }
+    
 
     #[test]
     fn eval_while_with_boolean() {
@@ -869,19 +968,24 @@ mod tests {
          *   After executing this program 'y' must be equal 1073741824
          *   and 'x' must be equal false
          */
-
-        let env = HashMap::new();
+    
+        let mut env = HashMap::new();
         let mut type_env = HashMap::new(); 
-
-
+    
+        // Initial assignments
         let a1 = Assignment(String::from("x"), Box::new(CTrue));
         let a2 = Assignment(String::from("y"), Box::new(CInt(1)));
+        
+        // Assign false to 'x' when y > 1e9
         let a3 = Assignment(String::from("x"), Box::new(CFalse));
+        
+        // Doubling 'y'
         let a4 = Assignment(
             String::from("y"),
             Box::new(Mul(Box::new(Var(String::from("y"))), Box::new(CInt(2)))),
         );
-
+    
+        // If statement to check if y > 1e9, if true set x to false else double y
         let if_then_else_statement = IfThenElse(
             Box::new(GT(
                 Box::new(Var(String::from("y"))),
@@ -890,25 +994,30 @@ mod tests {
             Box::new(a3),
             Some(Box::new(a4)),
         );
-
+    
+        // While loop that runs while x is true
         let while_statement = While(
             Box::new(Var(String::from("x"))),
             Box::new(if_then_else_statement),
         );
-
+    
+        // Sequence of statements
         let program = Sequence(
             Box::new(a1),
             Box::new(Sequence(Box::new(a2), Box::new(while_statement))),
         );
-
-        match execute(program, env, &mut type_env) {
+    
+        // Execute the program
+        match execute(program, &mut env, &mut type_env) {
             Ok(new_env) => {
+                // Check if x is false and y is 1073741824 after the loop
                 assert_eq!(new_env.get("x"), Some(&CFalse));
                 assert_eq!(new_env.get("y"), Some(&CInt(1073741824)));
             }
             Err(s) => assert!(false, "{}", s),
         }
     }
+    
 
     // #[test]
     // fn eval_while_loop_decrement() {
@@ -1012,7 +1121,7 @@ mod tests {
          *
          * After executing, 'x' should be 5, 'y' should be 0, and 'z' should be 13.
          */
-        let env = HashMap::new();
+        let mut env = HashMap::new();
         let mut type_env = HashMap::new(); 
 
         let a1 = Assignment(String::from("x"), Box::new(CInt(5)));
@@ -1027,7 +1136,7 @@ mod tests {
 
         let program = Sequence(Box::new(a1), Box::new(Sequence(Box::new(a2), Box::new(a3))));
 
-        match execute(program, env, &mut type_env) {
+        match execute(program, &mut env, &mut type_env) {
             Ok(new_env) => {
                 assert_eq!(new_env.get("x"), Some(&CInt(5)));
                 assert_eq!(new_env.get("y"), Some(&CInt(0)));
@@ -1040,18 +1149,30 @@ mod tests {
     #[test]
     fn evaluate_simple_constructor() {
         let env = HashMap::new();
+        let mut type_env = HashMap::new();
+
+        type_env.insert("Option".to_string(), vec![ValueConstructor { 
+            name: "Some".to_string(), 
+            types: vec![Type::TInteger], // Ajuste o tipo conforme necessário
+        }]);
+        
         let expr = Expression::Constructor(
             "Some".to_string(),
             vec![Box::new(Expression::CInt(42))],
         );
 
-        let result = eval(expr, &env);
+        let result = eval(expr, &env, &type_env);
         assert_eq!(result, Ok(Expression::Constructor("Some".to_string(), vec![Box::new(Expression::CInt(42))])));
     }
 
-    #[test]
+    #[test] 
     fn evaluate_constructor_with_expression() {
         let env = HashMap::new();
+        let mut type_env = HashMap::new();
+        type_env.insert("Option".to_string(), vec![ValueConstructor { 
+            name: "Some".to_string(), 
+            types: vec![Type::TInteger], // Ajuste o tipo conforme necessário
+        }]);
         let expr = Expression::Constructor(
             "Some".to_string(),
             vec![Box::new(Expression::Add(
@@ -1060,13 +1181,23 @@ mod tests {
             ))],
         );
 
-        let result = eval(expr, &env);
+        let result = eval(expr, &env, &type_env);
         assert_eq!(result, Ok(Expression::Constructor("Some".to_string(), vec![Box::new(Expression::CInt(42))])));
     }
 
     #[test]
     fn evaluate_nested_constructors() {
         let env = HashMap::new();
+        let mut type_env = HashMap::new();
+        type_env.insert("Option".to_string(), vec![ValueConstructor { 
+            name: "Some".to_string(), 
+            types: vec![Type::TInteger], 
+        }]);
+        type_env.insert("Pair".to_string(), vec![ValueConstructor { 
+            name: "Pair".to_string(), 
+            types: vec![Type::TInteger, Type::TInteger],  // Ajuste os tipos conforme necessário
+        }]);
+
         let expr = Expression::Constructor(
             "Pair".to_string(),
             vec![
@@ -1078,7 +1209,7 @@ mod tests {
             ],
         );
 
-        let result = eval(expr, &env);
+        let result = eval(expr, &env, &type_env);
         assert_eq!(
             result,
             Ok(Expression::Constructor(
@@ -1092,53 +1223,10 @@ mod tests {
     }
 
     #[test]
-    fn execute_perhaps_adt() {
-        let env = HashMap::new();
-        let mut type_env = HashMap::new();
-
-        // Declare the Perhaps ADT correctly
-        let stmt = Statement::ADTDeclaration(
-            "Perhaps".to_string(),
-            vec![
-                ValueConstructor {name: "probablyYes".to_string(), types: vec![]},
-                ValueConstructor {name: "probablyNo".to_string(), types: vec![]},
-            ],
-        );
-
-        let result = execute(stmt, env.clone(), &mut type_env);
-
-        // Check if declaration was successful
-        assert!(result.is_ok());
-        assert!(type_env.contains_key("Perhaps"));
-        assert_eq!(type_env.get("Perhaps").unwrap().len(), 2);
-
-        // Evaluate `Perhaps::ProbablyYes(42)`
-        let expr = Expression::Constructor(
-            "ProbablyYes".to_string(),
-            vec![Box::new(Expression::CInt(42))],
-        );
-
-        let eval_result = eval(expr, &env);
-        assert_eq!(
-            eval_result,
-            Ok(Expression::Constructor(
-                "ProbablyYes".to_string(),
-                vec![Box::new(Expression::CInt(42))]
-            ))
-        );
-
-        // Evaluate `Perhaps::ProbablyNo`
-        let expr_no = Expression::Constructor("ProbablyNo".to_string(), vec![]);
-        let eval_no = eval(expr_no, &env);
-        assert_eq!(eval_no, Ok(Expression::Constructor("ProbablyNo".to_string(), vec![])));
-    }
-
-
-    #[test]
     fn test_adt_geometric_shapes() {
         use crate::ir::ast::Type;
 
-        let env = HashMap::new();
+        let mut env = HashMap::new();
         let mut type_env = HashMap::new();
 
         // Declare the Shape ADT
@@ -1154,7 +1242,7 @@ mod tests {
         
 
         // Execute the ADT declaration
-        let result = execute(stmt, env.clone(), &mut type_env);
+        let result = execute(stmt, &mut env, &mut type_env);
         assert!(result.is_ok());
         assert!(type_env.contains_key("Shape"));
         assert_eq!(type_env.get("Shape").unwrap().len(), 3);
@@ -1164,7 +1252,7 @@ mod tests {
             "Circle".to_string(),
             vec![Box::new(Expression::CInt(10))],
         );
-        let eval_circle = eval(expr_circle.clone(), &env);
+        let eval_circle = eval(expr_circle.clone(), &env, &type_env);
         assert_eq!(eval_circle, Ok(expr_circle));
 
         // Test Rectangle(4, 5)
@@ -1175,7 +1263,7 @@ mod tests {
                 Box::new(Expression::CInt(5)),
             ],
         );
-        let eval_rectangle = eval(expr_rectangle.clone(), &env);
+        let eval_rectangle = eval(expr_rectangle.clone(), &env, &type_env);
         assert_eq!(eval_rectangle, Ok(expr_rectangle));
 
         // Test Triangle(3, 6)
@@ -1186,7 +1274,7 @@ mod tests {
                 Box::new(Expression::CInt(6)),
             ],
         );
-        let eval_triangle = eval(expr_triangle.clone(), &env);
+        let eval_triangle = eval(expr_triangle.clone(), &env, &type_env);
         assert_eq!(eval_triangle, Ok(expr_triangle));
     }
 

--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -24,7 +24,7 @@ pub fn eval(exp: Expression, env: &Environment, type_env: &TypeEnvironment) -> R
         Expression::GTE(lhs, rhs) => gte(*lhs, *rhs, env, type_env),
         Expression::LTE(lhs, rhs) => lte(*lhs, *rhs, env, type_env),
         Expression::Var(name) => lookup(name, env),
-        Expression::Constructor(name, args) => constructor_eval(name, args, env, type_env),
+        Expression::ADTConstructor(name, args) => constructor_eval(name, args, env, type_env),
         _ if is_constant(exp.clone()) => Ok(exp),
         _ => Err(String::from("Not implemented yet.")),
     }
@@ -58,7 +58,7 @@ fn constructor_eval(
                 .map(|arg| eval(*arg, env, type_env).map(Box::new))
                 .collect();
 
-        evaluated_args.map(|evaluated| Expression::Constructor(name, evaluated))
+        evaluated_args.map(|evaluated| Expression::ADTConstructor(name, evaluated))
     } else {
         Err(format!("Erro: Construtor {} não encontrado", name))
     }
@@ -1156,13 +1156,13 @@ mod tests {
             types: vec![Type::TInteger], // Ajuste o tipo conforme necessário
         }]);
         
-        let expr = Expression::Constructor(
+        let expr = Expression::ADTConstructor(
             "Some".to_string(),
             vec![Box::new(Expression::CInt(42))],
         );
 
         let result = eval(expr, &env, &type_env);
-        assert_eq!(result, Ok(Expression::Constructor("Some".to_string(), vec![Box::new(Expression::CInt(42))])));
+        assert_eq!(result, Ok(Expression::ADTConstructor("Some".to_string(), vec![Box::new(Expression::CInt(42))])));
     }
 
     #[test] 
@@ -1173,7 +1173,7 @@ mod tests {
             name: "Some".to_string(), 
             types: vec![Type::TInteger], // Ajuste o tipo conforme necessário
         }]);
-        let expr = Expression::Constructor(
+        let expr = Expression::ADTConstructor(
             "Some".to_string(),
             vec![Box::new(Expression::Add(
                 Box::new(Expression::CInt(10)),
@@ -1182,7 +1182,7 @@ mod tests {
         );
 
         let result = eval(expr, &env, &type_env);
-        assert_eq!(result, Ok(Expression::Constructor("Some".to_string(), vec![Box::new(Expression::CInt(42))])));
+        assert_eq!(result, Ok(Expression::ADTConstructor("Some".to_string(), vec![Box::new(Expression::CInt(42))])));
     }
 
     #[test]
@@ -1198,10 +1198,10 @@ mod tests {
             types: vec![Type::TInteger, Type::TInteger],  // Ajuste os tipos conforme necessário
         }]);
 
-        let expr = Expression::Constructor(
+        let expr = Expression::ADTConstructor(
             "Pair".to_string(),
             vec![
-                Box::new(Expression::Constructor(
+                Box::new(Expression::ADTConstructor(
                     "Some".to_string(),
                     vec![Box::new(Expression::CInt(10))],
                 )),
@@ -1212,10 +1212,10 @@ mod tests {
         let result = eval(expr, &env, &type_env);
         assert_eq!(
             result,
-            Ok(Expression::Constructor(
+            Ok(Expression::ADTConstructor(
                 "Pair".to_string(),
                 vec![
-                    Box::new(Expression::Constructor("Some".to_string(), vec![Box::new(Expression::CInt(10))])),
+                    Box::new(Expression::ADTConstructor("Some".to_string(), vec![Box::new(Expression::CInt(10))])),
                     Box::new(Expression::CInt(20))
                 ]
             ))
@@ -1248,7 +1248,7 @@ mod tests {
         assert_eq!(type_env.get("Shape").unwrap().len(), 3);
 
         // Test Circle(10)
-        let expr_circle = Expression::Constructor(
+        let expr_circle = Expression::ADTConstructor(
             "Circle".to_string(),
             vec![Box::new(Expression::CInt(10))],
         );
@@ -1256,7 +1256,7 @@ mod tests {
         assert_eq!(eval_circle, Ok(expr_circle));
 
         // Test Rectangle(4, 5)
-        let expr_rectangle = Expression::Constructor(
+        let expr_rectangle = Expression::ADTConstructor(
             "Rectangle".to_string(),
             vec![
                 Box::new(Expression::CInt(4)),
@@ -1267,7 +1267,7 @@ mod tests {
         assert_eq!(eval_rectangle, Ok(expr_rectangle));
 
         // Test Triangle(3, 6)
-        let expr_triangle = Expression::Constructor(
+        let expr_triangle = Expression::ADTConstructor(
             "Triangle".to_string(),
             vec![
                 Box::new(Expression::CInt(3)),

--- a/src/interpreter/interpreter.rs
+++ b/src/interpreter/interpreter.rs
@@ -6,6 +6,8 @@ type ErrorMessage = String;
 
 type Environment = HashMap<Name, Expression>;
 type TypeEnvironment = HashMap<Name, Vec<ValueConstructor>>; // Store ADT Definitions
+
+
 pub fn eval(exp: Expression, env: &Environment) -> Result<Expression, ErrorMessage> {
     match exp {
         Expression::Add(lhs, rhs) => add(*lhs, *rhs, env),
@@ -61,7 +63,7 @@ fn eval_binary_arith_op<F>(
     op: F,
     error_msg: &str,
 ) -> Result<Expression, ErrorMessage>
-where
+where 
     F: Fn(f64, f64) -> f64,
 {
     let v1 = eval(lhs, env)?;
@@ -1098,8 +1100,8 @@ mod tests {
         let stmt = Statement::ADTDeclaration(
             "Perhaps".to_string(),
             vec![
-                ValueConstructor::Constructor("ProbablyYes".to_string(), vec![]),
-                ValueConstructor::Constructor("ProbablyNo".to_string(), vec![]),
+                ValueConstructor {name: "probablyYes".to_string(), types: vec![]},
+                ValueConstructor {name: "probablyNo".to_string(), types: vec![]},
             ],
         );
 
@@ -1143,9 +1145,10 @@ mod tests {
         let stmt = Statement::ADTDeclaration(
             "Shape".to_string(),
             vec![
-                ValueConstructor::Constructor("Circle".to_string(), vec![Type::TInteger]),
-                ValueConstructor::Constructor("Rectangle".to_string(), vec![Type::TInteger, Type::TInteger]),
-                ValueConstructor::Constructor("Triangle".to_string(), vec![Type::TInteger, Type::TInteger]),
+                ValueConstructor { name : "Circle".to_string(), types: vec![Type::TInteger]},
+                ValueConstructor { name : "Rectangle".to_string(), types: vec![Type::TInteger, Type::TInteger]},
+                ValueConstructor { name : "Triangle".to_string(), types: vec![Type::TInteger, Type::TInteger]},
+            
             ],
         );
         

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -8,16 +8,15 @@ pub enum Type {
     TString,
     TList(Box<Type>),
     TTuple(Vec<Type>),
+    Adt(Name, Vec<ValueConstructor>),
 }
 
 #[derive(Debug,PartialEq, Clone)]
-pub enum ValueConstructor{
-    Constructor(Name, Vec<Type>),
+pub struct  ValueConstructor{
+    pub name: Name,
+    pub types: Vec<Type> 
 }
-#[derive(Debug, PartialEq)]
-pub enum ADT {
-    DataType(Name, Vec<ValueConstructor>),
-}
+
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
@@ -50,8 +49,8 @@ pub enum Expression {
     GTE(Box<Expression>, Box<Expression>),
     LTE(Box<Expression>, Box<Expression>),
 
-     /* ADT Constructor */
-     Constructor(Name, Vec<Box<Expression>>), //////// NEW: ADT constructor support
+    /* ADT Constructor */
+    Constructor(Name, Vec<Box<Expression>>), // NEW: ADT constructor support
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -1,6 +1,6 @@
 pub type Name = String;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum Type {
     TInteger,
     TBool,
@@ -10,7 +10,7 @@ pub enum Type {
     TTuple(Vec<Type>),
 }
 
-#[derive(Debug,PartialEq)]
+#[derive(Debug,PartialEq, Clone)]
 pub enum ValueConstructor{
     Constructor(Name, Vec<Type>),
 }
@@ -49,6 +49,9 @@ pub enum Expression {
     LT(Box<Expression>, Box<Expression>),
     GTE(Box<Expression>, Box<Expression>),
     LTE(Box<Expression>, Box<Expression>),
+
+     /* ADT Constructor */
+     Constructor(Name, Vec<Box<Expression>>), //////// NEW: ADT constructor support
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -58,5 +61,6 @@ pub enum Statement {
     Assignment(Name, Box<Expression>),
     IfThenElse(Box<Expression>, Box<Statement>, Option<Box<Statement>>),
     While(Box<Expression>, Box<Statement>),
-    Sequence(Box<Statement>, Box<Statement>),
+    Sequence(Box<Statement>, Box<Statement>), 
+    ADTDeclaration(Name, Vec<ValueConstructor>),
 }

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -8,7 +8,7 @@ pub enum Type {
     TString,
     TList(Box<Type>),
     TTuple(Vec<Type>),
-    Adt(Name, Vec<ValueConstructor>),
+    Tadt(Name, Vec<ValueConstructor>),
 }
 
 #[derive(Debug,PartialEq, Clone)]

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -50,7 +50,7 @@ pub enum Expression {
     LTE(Box<Expression>, Box<Expression>),
 
     /* ADT Constructor */
-    Constructor(Name, Vec<Box<Expression>>), // NEW: ADT constructor support
+    ADTConstructor(Name, Vec<Box<Expression>>),
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/ir/ast.rs
+++ b/src/ir/ast.rs
@@ -10,6 +10,15 @@ pub enum Type {
     TTuple(Vec<Type>),
 }
 
+#[derive(Debug,PartialEq)]
+pub enum ValueConstructor{
+    Constructor(Name, Vec<Type>),
+}
+#[derive(Debug, PartialEq)]
+pub enum ADT {
+    DataType(Name, Vec<ValueConstructor>),
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub enum Expression {
     /* constants */

--- a/src/tc/type_checker.rs
+++ b/src/tc/type_checker.rs
@@ -112,7 +112,7 @@ fn check_adt_constructor(
 }
 
 fn check_adt(adt: Type, _env: &HashMap<Name, Type>) -> Result<(), String> {
-    if let Type::Adt(name, constructors) = adt {
+    if let Type::Tadt(name, constructors) = adt {
         if name.is_empty() {
             return Err("DataType name cannot be empty".to_string());
         }
@@ -171,7 +171,7 @@ mod tests {
 fn check_valid_adt() {
     let env = HashMap::new();
     
-    let adt = Type::Adt(
+    let adt = Type::Tadt(
         "Option".to_string(),
         vec![
             ValueConstructor {
@@ -192,7 +192,7 @@ fn check_valid_adt() {
 fn check_invalid_adt() {
     let env = HashMap::new();
     
-    let adt = Type::Adt(
+    let adt = Type::Tadt(
         "Invalid".to_string(),
         vec![
             ValueConstructor {
@@ -339,7 +339,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_valid_simple_adt() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "Option".to_string(),
             vec![
                 ValueConstructor {
@@ -358,7 +358,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_valid_complex_adt() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "Result".to_string(),
             vec![
                 ValueConstructor {
@@ -377,7 +377,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_invalid_adt_with_empty_name() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "".to_string(),
             vec![ValueConstructor {
                 name: "None".to_string(),
@@ -390,7 +390,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_invalid_constructor_with_empty_name() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "Option".to_string(),
             vec![ValueConstructor {
                 name: "".to_string(),
@@ -403,7 +403,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_valid_nested_adt() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "Tree".to_string(),
             vec![
                 ValueConstructor {
@@ -422,7 +422,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_invalid_nested_adt() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "Tree".to_string(),
             vec![
                 ValueConstructor {
@@ -441,7 +441,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_valid_recursive_adt() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "List".to_string(),
             vec![
                 ValueConstructor {
@@ -460,7 +460,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_invalid_recursive_adt_with_mismatch() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "List".to_string(),
             vec![
                 ValueConstructor {
@@ -479,7 +479,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_invalid_adt_with_duplicate_constructors() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "Option".to_string(),
             vec![
                 ValueConstructor {
@@ -498,7 +498,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_valid_adt_with_list_and_tuple() {
         let env = HashMap::new();
-        let adt = Type::Adt(
+        let adt = Type::Tadt(
             "Complex".to_string(),
             vec![
                 ValueConstructor {
@@ -516,7 +516,7 @@ fn check_invalid_adt() {
     #[test]
     fn check_adt_with_empty_constructors_list() {
         let env = HashMap::new();
-        let adt = Type::Adt("Empty".to_string(), vec![]); // Valid ADT with no constructors
+        let adt = Type::Tadt("Empty".to_string(), vec![]); // Valid ADT with no constructors
         assert_eq!(check_adt(adt, &env), Ok(()));
     }
     


### PR DESCRIPTION
## Description
This PR introduces the first implementation of the type-checking module based on the design agreed upon during our discussions. The goal is to provide a robust and extensible foundation for type-checking ADT constructors and expressions.

## Changes
- Added the of ADT in `type checker, ast` and `interpreter`

## Design Decisions
- The design follows the agreed-upon approach of separating type-checking logic into modular functions (e.g., `check_bin_arithmetic_expression`, `check_adt_constructor`).
- Trade-offs:
  - Chose to return detailed error messages for type mismatches instead of generic errors.
  - Decided to use `Box<Expression>` to handle recursive expressions efficiently.

## Testing
- Added unit tests for all new functions, covering edge cases like type mismatches and zero-argument constructors.
- Manual testing was performed to verify the correctness of the type-checking logic.

## Notes for Reviewers
- Please pay special attention to the `check_adt_constructor` function, as it handles the core logic for ADT validation.
- The environment setup in `setup_environment` might need review to ensure it aligns with the expected ADT definitions.
- Known issue: The error messages for nested ADTs are not yet fully implemented (TODO).
- The warning about the inclusion of ValueConstructor is not solved (DO NOT GET RID OF ITS IMPORT IN TYPE CHECKER )
